### PR TITLE
APISpec core files

### DIFF
--- a/starlette_web/common/apispec/introspection.py
+++ b/starlette_web/common/apispec/introspection.py
@@ -1,0 +1,115 @@
+# Modification of https://github.com/Woile/starlette-apispec/blob/master/starlette_apispec/schemas.py  # noqa: E501
+from collections import deque
+from typing import List
+
+from apispec import APISpec
+from apispec.exceptions import DuplicateComponentNameError
+from starlette.routing import BaseRoute, Mount, Route
+from starlette.schemas import BaseSchemaGenerator, EndpointInfo
+
+from starlette_web.common.i18n import gettext
+from starlette_web.contrib.auth.backend import BaseAuthenticationBackend
+from starlette_web.common.apispec.schemas import get_error_schema_class
+
+
+# TODO: custom EndpointInfo with link to endpoint class
+# TODO: maybe allow user to override class in settings (?)
+class APISpecSchemaGenerator(BaseSchemaGenerator):
+    ERROR_SCHEMA_NAME = "Error"
+
+    def __init__(self, spec: APISpec) -> None:
+        self.spec: APISpec = spec
+        self.security_schemas = {}
+        self.paths_and_endpoints = {}
+
+    def _fetch_paths_and_endpoints(self, initial_routes: List[BaseRoute]):
+        if self.paths_and_endpoints:
+            return self.paths_and_endpoints
+
+        mounts = deque([])
+        routes = {}
+
+        for route in initial_routes:
+            # Skip any websocket connections
+            if isinstance(route, Mount):
+                mounts.append((route.path, route))
+            elif isinstance(route, Route) and getattr(route, "include_in_schema", True):
+                routes[route.path] = route.endpoint
+
+        while mounts:
+            path, mount = mounts.popleft()
+            for route in mount.routes:
+                # Skip any websocket connections
+                if isinstance(route, Mount):
+                    mounts.append((path + route.path, route))
+                elif isinstance(route, Route) and getattr(route, "include_in_schema", True):
+                    routes[path + route.path] = route.endpoint
+
+        self.paths_and_endpoints = routes
+
+    def _add_security_schema(self, auth_backend: BaseAuthenticationBackend) -> str:
+        auth_name = getattr(auth_backend, "openapi_name", None) or auth_backend.__name__
+
+        if auth_name in self.security_schemas:
+            if self.security_schemas[auth_name] != auth_backend:
+                raise DuplicateComponentNameError(
+                    gettext("Duplicate auth_backend $auth_name", auth_name=auth_name)
+                )
+        else:
+            self.security_schemas[auth_name] = auth_backend
+            self.spec.components.security_scheme(auth_name, auth_backend.openapi_spec)
+
+        return auth_name
+
+    def _populate_security_schema(self, endpoint: EndpointInfo, parsed_docstring: dict):
+        if parsed_docstring.get("security"):
+            return
+
+        kls = self.paths_and_endpoints[endpoint.path]
+        if not getattr(kls, "auth_backend", None):
+            return
+
+        if getattr(kls.auth_backend, "openapi_spec", None):
+            security_schema = self._add_security_schema(kls.auth_backend)
+            # TODO: examine, if something should be passed into dict object
+            parsed_docstring["security"] = [{security_schema: []}]
+
+    def _populate_auth_errors(self, endpoint: EndpointInfo, parsed_docstring: dict):
+        kls = self.paths_and_endpoints[endpoint.path]
+
+        if getattr(kls, "auth_backend", None):
+            parsed_docstring["responses"] = {
+                **parsed_docstring.get("responses", {}),
+                "401": {
+                    "description": gettext("Authentication error."),
+                    "content": {"application/json": {"schema": self.ERROR_SCHEMA_NAME}},
+                },
+            }
+
+        if getattr(kls, "permission_classes", []):
+            parsed_docstring["responses"] = {
+                **parsed_docstring.get("responses", {}),
+                "403": {
+                    "description": gettext("Access forbidden."),
+                    "content": {"application/json": {"schema": self.ERROR_SCHEMA_NAME}},
+                },
+            }
+
+    def get_schema(self, routes: List[BaseRoute]) -> dict:
+        ErrorResponseSchema = get_error_schema_class()()
+        self.spec.components.schema(self.ERROR_SCHEMA_NAME, schema=ErrorResponseSchema)
+
+        endpoints = self.get_endpoints(routes)
+        self._fetch_paths_and_endpoints(routes)
+
+        for endpoint in endpoints:
+            parsed = self.parse_docstring(endpoint.func)
+            self._populate_security_schema(endpoint, parsed)
+            self._populate_auth_errors(endpoint, parsed)
+
+            self.spec.path(
+                path=endpoint.path,
+                operations={endpoint.http_method: parsed},
+            )
+
+        return self.spec.to_dict()

--- a/starlette_web/common/apispec/marshmallow/__init__.py
+++ b/starlette_web/common/apispec/marshmallow/__init__.py
@@ -1,0 +1,10 @@
+from apispec.ext.marshmallow import MarshmallowPlugin
+
+from starlette_web.common.apispec.marshmallow.converters import (
+    StarletteWebMarshmallowOpenAPIConverter,
+)
+
+
+# TODO: maybe allow user to override class in settings (?)
+class StarletteWebMarshmallowPlugin(MarshmallowPlugin):
+    Converter = StarletteWebMarshmallowOpenAPIConverter

--- a/starlette_web/common/apispec/marshmallow/converters.py
+++ b/starlette_web/common/apispec/marshmallow/converters.py
@@ -1,0 +1,35 @@
+import json
+
+from apispec.ext.marshmallow import OpenAPIConverter
+from apispec.ext.marshmallow.field_converter import DEFAULT_FIELD_MAPPING
+import marshmallow
+
+from starlette_web.common.utils.json import StarletteJSONEncoder
+
+
+# TODO: maybe allow user to override class in settings (?)
+class StarletteWebMarshmallowOpenAPIConverter(OpenAPIConverter):
+    # Decimal has no specific representation in OpenAPI standard
+    # Support decimal representation in a same way, as drf-yasg does for Django
+    # https://github.com/axnsan12/drf-yasg/blob/b99306f71c6a5779b62189df7d9c1f5ea1c794ef/src/drf_yasg/openapi.py#L48  # noqa: E501
+    field_mapping = {
+        **DEFAULT_FIELD_MAPPING,
+        marshmallow.fields.Decimal: ("string", "decimal"),
+    }
+
+    def field2choices(self, field, **kwargs):
+        res = super().field2choices(field, **kwargs)
+        return json.loads(StarletteJSONEncoder().encode(res))
+
+    def fields2jsonschema(self, fields, *, ordered=False, partial=None):
+        res = super().fields2jsonschema(fields, ordered=ordered, partial=partial)
+
+        # TODO: this field must be redefined to support changes to schema via renderer_class, i.e.
+        """
+        if 'required' in res and type(res['required']) is list:
+            res['required'] = [camelize_key(d) for d in res['required']]
+        if res.get('properties'):
+            res['properties'] = camelize(res['properties'])
+        return camelize(res)
+        """
+        return res

--- a/starlette_web/common/apispec/schemas.py
+++ b/starlette_web/common/apispec/schemas.py
@@ -14,6 +14,7 @@ class ErrorDetailsSchema(Schema):
     details = fields.Raw(required=False, allow_none=True)
 
 
+# TODO: maybe move from common.apispec to common.elsewhere (?)
 class ErrorResponseSchema(Schema):
     payload = fields.Nested(ErrorDetailsSchema, required=True)
     status = fields.String(required=False, allow_none=False)

--- a/starlette_web/common/apispec/schemas.py
+++ b/starlette_web/common/apispec/schemas.py
@@ -1,0 +1,28 @@
+from typing import Type
+
+from marshmallow import Schema, fields
+
+from starlette_web.common.conf import settings
+from starlette_web.common.utils import import_string
+
+
+__ERROR_RESPONSE_SCHEMA = None
+
+
+class ErrorDetailsSchema(Schema):
+    error = fields.String(required=True, allow_none=False)
+    details = fields.Raw(required=False, allow_none=True)
+
+
+class ErrorResponseSchema(Schema):
+    payload = fields.Nested(ErrorDetailsSchema, required=True)
+    status = fields.String(required=False, allow_none=False)
+
+
+def get_error_schema_class() -> Type[Schema]:
+    global __ERROR_RESPONSE_SCHEMA
+    if __ERROR_RESPONSE_SCHEMA is not None:
+        return __ERROR_RESPONSE_SCHEMA
+
+    __ERROR_RESPONSE_SCHEMA = import_string(settings.ERROR_RESPONSE_SCHEMA)
+    return __ERROR_RESPONSE_SCHEMA

--- a/starlette_web/common/authorization/backends.py
+++ b/starlette_web/common/authorization/backends.py
@@ -6,6 +6,9 @@ from starlette_web.common.http.requests import PRequest
 
 
 class BaseAuthenticationBackend:
+    openapi_spec = None
+    openapi_name = "Base"
+
     def __init__(self, request: PRequest, scope: Scope):
         self.request: PRequest = request
         self.db_session: AsyncSession = request.db_session
@@ -16,5 +19,7 @@ class BaseAuthenticationBackend:
 
 
 class NoAuthenticationBackend(BaseAuthenticationBackend):
+    openapi_name = "NoAuth"
+
     async def authenticate(self) -> BaseUserMixin:
         return AnonymousUser()

--- a/starlette_web/common/http/exception_handlers.py
+++ b/starlette_web/common/http/exception_handlers.py
@@ -48,9 +48,7 @@ class BaseExceptionHandler:
             payload["details"] = self._get_error_details(request, exc)
 
         error_schema = get_error_schema_class()()
-        print(error_schema)
         res = {"status": str(response_status), "payload": payload}
-        print(res, error_schema.dump(res))
         return error_schema.dump(res)
 
     def _on_error_action(self, request: PRequest, exc: Exception):

--- a/starlette_web/common/http/statuses.py
+++ b/starlette_web/common/http/statuses.py
@@ -1,7 +1,7 @@
-import enum
+from starlette_web.common.utils import TextChoices
 
 
-class ResponseStatus(str, enum.Enum):
+class ResponseStatus(TextChoices):
     OK = "OK"
     INTERNAL_ERROR = "INTERNAL_ERROR"
     AUTH_FAILED = "AUTH_FAILED"

--- a/starlette_web/common/i18n/__init__.py
+++ b/starlette_web/common/i18n/__init__.py
@@ -1,0 +1,6 @@
+# Stub file for future i18n
+from string import Template
+
+
+def gettext(message, _lang=None, **kwargs):
+    return Template(message).safe_substitute(**kwargs)

--- a/starlette_web/common/utils/__init__.py
+++ b/starlette_web/common/utils/__init__.py
@@ -1,5 +1,6 @@
 # flake8: noqa
 
+from starlette_web.common.utils.choices import TextChoices, IntegerChoices
 from starlette_web.common.utils.crypto import get_random_string, constant_time_compare
 from starlette_web.common.utils.importing import import_string
 from starlette_web.common.utils.json import StarletteJSONEncoder

--- a/starlette_web/common/utils/choices.py
+++ b/starlette_web/common/utils/choices.py
@@ -1,0 +1,74 @@
+# Copy of https://github.com/django/django/blob/main/django/db/models/enums.py
+import enum
+
+__all__ = ["Choices", "IntegerChoices", "TextChoices"]
+
+
+class ChoicesMeta(enum.EnumMeta):
+    """A metaclass for creating a enum choices."""
+
+    def __new__(metacls, classname, bases, classdict):
+        labels = []
+        for key in classdict._member_names:
+            value = classdict[key]
+            label = key.replace("_", " ").title()
+            labels.append(label)
+            # Use dict.__setitem__() to suppress defenses against double
+            # assignment in enum's classdict.
+            dict.__setitem__(classdict, key, value)
+        cls = super().__new__(metacls, classname, bases, classdict)
+        cls._value2label_map_ = dict(zip(cls._value2member_map_, labels))
+        # Add a label property to instances of enum which uses the enum member
+        # that is passed in as "self" as the value to use when looking up the
+        # label in the choices.
+        cls.label = property(lambda self: cls._value2label_map_.get(self.value))
+        cls.do_not_call_in_templates = True
+        return enum.unique(cls)
+
+    def __contains__(cls, member):
+        if not isinstance(member, enum.Enum):
+            # Allow non-enums to match against member values.
+            return any(x.value == member for x in cls)
+        return super().__contains__(member)
+
+    @property
+    def names(cls):
+        empty = ["__empty__"] if hasattr(cls, "__empty__") else []
+        return empty + [member.name for member in cls]
+
+    @property
+    def choices(cls):
+        empty = [(None, cls.__empty__)] if hasattr(cls, "__empty__") else []
+        return empty + [(member.value, member.label) for member in cls]
+
+    @property
+    def labels(cls):
+        return [label for _, label in cls.choices]
+
+    @property
+    def values(cls):
+        return [value for value, _ in cls.choices]
+
+
+class Choices(enum.Enum, metaclass=ChoicesMeta):
+    """Class for creating enumerated choices."""
+
+    def __str__(self):
+        """
+        Use value when cast to str, so that Choices set as model instance
+        attributes are rendered as expected in templates and similar contexts.
+        """
+        return str(self.value)
+
+
+class IntegerChoices(int, Choices):
+    """Class for creating enumerated integer choices."""
+
+    pass
+
+
+class TextChoices(str, Choices):
+    """Class for creating enumerated string choices."""
+
+    def _generate_next_value_(name, start, count, last_values):
+        return name

--- a/starlette_web/contrib/auth/backend.py
+++ b/starlette_web/contrib/auth/backend.py
@@ -19,6 +19,8 @@ class JWTAuthenticationBackend(BaseAuthenticationBackend):
     """Core of authenticate system, based on JWT auth approach"""
 
     keyword = "Bearer"
+    openapi_spec = {"type": "http", "scheme": "bearer", "bearerFormat": "JWT"}
+    openapi_name = "JWTAuth"
 
     async def authenticate(self) -> User:
         request = self.request

--- a/starlette_web/core/settings.py
+++ b/starlette_web/core/settings.py
@@ -109,3 +109,5 @@ LOGGING = {
         "app": {"handlers": ["console"], "level": LOG_LEVEL, "propagate": False},
     },
 }
+
+ERROR_RESPONSE_SCHEMA = "starlette_web.common.apispec.schemas.ErrorResponseSchema"


### PR DESCRIPTION
This pull request provides core functionality of APISpecSchemaGenerator:

- introspect and insert security schemas from endpoint "authentication_classes"
- introspect and insert authentication and permission errors from endpoint "authentication_classes" and "permission_classes"
- handling decimal field with OpenAPI
- generic ErrorSchema for the project
- stub for i18n for future